### PR TITLE
Improve Jenkins README

### DIFF
--- a/jenkins/README-JENKINS.md
+++ b/jenkins/README-JENKINS.md
@@ -1,34 +1,34 @@
-RHTAP QE Jenkins Guide
-------------------------------------------------------------
+# RHTAP QE Jenkins Guide
 
-# Setup Jenkins on OpenShift 
+## Setup Jenkins on OpenShift
 
 1. Login to OpenShift
-2. Create new project jenkins: oc new-project jenkins
-3. Create new build for jenkins agent(with buildah and other utilities for RHTAP pipelines):oc new-build --name jenkins-agent-base  --binary=true --strategy=docker
-4. Start new build: oc start-build jenkins-agent-base --from-file=./jenkins-agent/Dockerfile --wait --follow
-5. Deploy jenkins from openshift template: oc new-app -e JENKINS_PASSWORD=admin123 -e VOLUME_CAPACITY=10Gi jenkins-persistent 
-6. Upload new SecurityContextConstraints for Jenkins agent(for running jenkins agent in privileged mode): oc apply -f ./jenkins-agent/jenkins-agent-base-scc.yml
-7. Apply policy to Jenkins user(for running jenkins agent in privileged mode): oc adm policy add-scc-to-user jenkins-agent-base -z jenkins
-8. (Optional)You can check if the correct agent image is used and buildah is working by creating new pipeline from file pipeline-buildah
-9. Login in the Jenkins instance and lookup for your Jenkins User ID - you can see it when you click on your user on right top corner(like jkopriva@redhat.com-admin-edit-view, cluster-admin-admin-edit-view) and click on Configure and generate API token - you will need, URL, username and token for RHTAP installation, setting creds in Jenkins, running e2e tests
-10. You can continue with RHTAP Installation(do not forget to add Jenkins integration with correct parameters: Jenkins URL, username and token)
-11. REQUIRED You need to change in jenkins file "agent any" to https://github.com/redhat-appstudio/rhtap-utils/blob/main/jenkins/Jenkinsfile-jenkins-agent(you need to copy whole kubernetes settings)
-12. When you are creating a Job in Jenkins it needs to have same name as componnet to be picked up by RHDH
+2. `cd` to the directory that contains this README
+3. Run the [./jenkins-deploy.sh](./jenkins-deploy.sh) script
+4. (Optional) You can check if the pipeline uses the correct agent image and whether buildah is working
+    - In your Jenkins instance, click `+ New Item` and create a `Pipeline` style project
+    - Use the content of the [pipeline-buildah](./pipeline-buildah) file as the pipeline script
+    - Save the pipeline and trigger a new build. It should succeed and print the buildah help message
+5. Login in the Jenkins instance and get your username and token
+    - You can see the username when you click on your user in the top right corner (like `jkopriva@redhat.com-admin-edit-view`, `cluster-admin-admin-edit-view`)
+    - In the user menu, click on `Configure` and generate an API token
+    - You will need the username and token for RHTAP installation, setting creds in Jenkins, running e2e tests
+6. You can continue with RHTAP Installation (do not forget to add Jenkins integration with correct parameters: Jenkins URL, username and token)
+7. REQUIRED In your Jenkinsfile, change `agent any` to the content of [Jenkinsfile-jenkins-agent](./Jenkinsfile-jenkins-agent) (you need to copy the whole kubernetes settings)
+8. When you are creating a Job in Jenkins, it needs to have same the same name as the corresponding component to make RHDH associate them
 
-(For Jenkins installation you can also use jenkins-deploy.sh script)
+## Setup credentials for RHTAP Jenkins on OpenShift for testing
 
-# Setup creadentials for RHTAP Jenkins on OpenShift for testing
+1. Check credentials in [jenkins-credentials.sh](./jenkins-credentials.sh) (ACS endpoint, ACS token, GitOps token, Quay username/password) and values for your jenkins instance
+2. Run script [./jenkins-credentials.sh](./jenkins-credentials.sh)
+3. (For Gitlab you also need to add the `GITOPS_AUTH_USERNAME` variable)
 
-1. Check credentials in jenkins-credentials.sh (ACS endpoint, ACS token, GitOps token, Quay username/password) and values for your jenkins instance
-2. Run script ./jenkins-credentials.sh
-3. (For Gitlab you also need to add GITOPS_AUTH_USERNAME variable)
+## Common issues
 
-# Common issues:
- - I do not see Jenkins during creation of component - You have wrong URL to catalog URL, you can change it here: ns/rhtap/secrets/developer-hub-rhtap-env/yaml and kill old developer hub pods and wait for new ones
- - Jenkins Job is failing because some secret like GITOPS_AUTH_PASSWORD is not set(or any other variable) - You need to setup creds in jenkins for example with this file: https://github.com/redhat-appstudio/rhtap-utils/blob/a7e490b2ce4797bba112a08427aa9240e5207a0a/jenkins/jenkins-credentials.sh - or manually
+ - I do not see Jenkins during creation of component - You have wrong URL to catalog URL, you can change it here: `ns/rhtap/secrets/developer-hub-rhtap-env/yaml` and kill old developer hub pods and wait for new ones
+ - Jenkins Job is failing because some secret like `GITOPS_AUTH_PASSWORD` is not set(or any other variable) - You need to setup creds in jenkins for example with this file: [jenkins-credentials.sh](./jenkins-credentials.sh) - or manually
  - Buildah in jenkins job/pipeline does not work - You have not changed agent in Jenkinsfile or the jenkins agent pod does not run in privileged mode
- - Jenkins job status is not reported back to developer hub - You do not have correct credentials for Jenkins in developer hub, update  ns/rhtap/secrets/developer-hub-rhtap-env/yaml with correct creds
+ - Jenkins job status is not reported back to developer hub - You do not have correct credentials for Jenkins in developer hub, update `ns/rhtap/secrets/developer-hub-rhtap-env/yaml` with correct creds
  - 'Jenkins' doesn't have label 'jenkins-agent' - You need to setup correct Jenkins agent in your Jenkinsfile and check labels, if they are correct. Verify also Jenkins agent settings in Jenkinsfile.
  - `error: error processing template "openshift/jenkins-persistent": the namespace of the provided object does not match the namespace sent on the request`
    when running `oc new-app` - your `oc` version may be out of date, try downloading the latest version

--- a/jenkins/jenkins-deploy.sh
+++ b/jenkins/jenkins-deploy.sh
@@ -1,12 +1,18 @@
 #!/bin/bash
 set -e
 
+# Create new project 'jenkins'
 oc new-project jenkins
+# Create new build for jenkins agent (with buildah and other utilities for RHTAP pipelines)
 oc new-build --name jenkins-agent-base  --binary=true --strategy=docker
+# Start new build
 oc start-build jenkins-agent-base --from-file=./jenkins-agent/Dockerfile --wait --follow
-oc new-app -e JENKINS_PASSWORD=admin123 -e VOLUME_CAPACITY=10Gi jenkins-persistent 
-sleep 15 #it could take some time, until jenkins pod is created 
-kubectl -n jenkins wait pod --for=condition=ready=False -l openshift.io/deployer-pod-for.name=jenkins-1 --timeout=120s
-oc apply -f ./jenkins-agent/jenkins-agent-base-scc.yml 
+# Deploy jenkins from openshift template
+oc new-app -e JENKINS_PASSWORD=admin123 -e VOLUME_CAPACITY=10Gi jenkins-persistent
+
+sleep 15  # it could take some time, until jenkins pod is created
+
+# Upload new SecurityContextConstraints for Jenkins agent (for running jenkins agent in privileged mode)
+oc apply -f ./jenkins-agent/jenkins-agent-base-scc.yml
+# Apply policy to Jenkins user (for running jenkins agent in privileged mode)
 oc adm policy add-scc-to-user jenkins-agent-base -z jenkins
- 


### PR DESCRIPTION
* Don't list the deployment commands one by one, just link to the deploy script
  * Move the explanatory comments into the deploy script
* Explain how to use the pipeline-buildah file to check if things work
* Improve formatting
* Improve structure and wording