### PR TITLE
RHTAP-4794: git-cleanup-script: Sort the repos by name for deleting

### DIFF
--- a/git-org-cleanup/git-repo-cleanup.sh
+++ b/git-org-cleanup/git-repo-cleanup.sh
@@ -18,7 +18,7 @@ cutoff_time=$((now - 14 * 24 * 60 * 60))
 repo_name_regex="^[0-9a-z]{9}-(python|dotnet-basic|java-quarkus|go|nodejs|java-springboot)"
 
 # Fetch the list of repositories from GitHub API
-repos=$(curl -s -X GET -H "$AUTH_HEADER" "https://api.github.com/orgs/$GITHUB_ORG/repos?per_page=100")
+repos=$(curl -s -X GET -H "$AUTH_HEADER" "https://api.github.com/orgs/$GITHUB_ORG/repos?per_page=100&sort=name")
 if [ "$(echo $repos | jq -r .status 2>/dev/null)" ]; then
     echo "Error Fetching repositories '$repos' "
     exit 1


### PR DESCRIPTION
By default, curl command is getting latest repos created first, update the command to get it sort by name in order to delete them.