### PR TITLE
Update Jenkins Readme to reference runner image instead jenkins agent

### DIFF
--- a/jenkins/README-JENKINS.md
+++ b/jenkins/README-JENKINS.md
@@ -15,23 +15,18 @@
     - In the user menu, click on `Configure` and generate an API token
     - You will need the username and token for RHTAP installation, setting creds in Jenkins, running e2e tests...
 7. You can continue with RHTAP Installation (do not forget to add Jenkins integration with correct parameters: Jenkins URL, username and token)
-8. REQUIRED In your Jenkinsfile, change `agent any` to the content of [Jenkinsfile-jenkins-agent](./Jenkinsfile-jenkins-agent) (you need to copy the whole kubernetes settings)
-    - (Option A) You can build your own image on cluster, where you run the Jenkins, then you can use [Dockerfile](./jenkins-agent/Dockerfile) 
-    - (Option B) You can replace the image in `image-registry.openshift-image-registry.svc:5000/jenkins/jenkins-agent-base:latest` in [Jenkinsfile-jenkins-agent](./Jenkinsfile-jenkins-agent) to          `quay.io/jkopriva/rhtap-jenkins-agent:0.1`
-9. When you are creating a Job in Jenkins, it needs to have same the same name as the corresponding component to make RHDH associate them
+8. When you are creating a Job in Jenkins, it needs to have same the same name as the corresponding component to make RHDH associate them. For source repo job use the <component-name> for gitops repo job use <component-name>-gitops
 
 ## Setup credentials for RHTAP Jenkins on OpenShift for testing
 
-1. Check credentials in [jenkins-credentials.sh](./jenkins-credentials.sh) (ACS endpoint, ACS token, GitOps token, Quay username/password...) and values for your Jenkins instance(URL, username and token). For TRUSTIFICATION credentials either login to OpenShift with your RHTAP instance(enables automatic credentials upload) or insert the values manually
-2. Run script [./jenkins-credentials.sh](./jenkins-credentials.sh)
-3. (For GitLab you also need to add the `GITOPS_AUTH_USERNAME` variable)
+1. To populate all credential required by Jenkins job run [jenkins-credentials.sh](./jenkins-credentials.sh) script
+    - Make sure you have jenkins integration secret in place
+    - Make sure you have deployed tssc using the installer
 
 ## Common issues
 
- - I do not see Jenkins during creation of component - You have wrong URL to catalog URL, you can change it here: `ns/rhtap/secrets/developer-hub-rhtap-env/yaml` and kill old developer hub pods and wait for new ones
- - Jenkins Job is failing because some secret like `GITOPS_AUTH_PASSWORD` is not set(or any other variable) - You need to setup creds in jenkins for example with this file: [jenkins-credentials.sh](./jenkins-credentials.sh) - or manually
+ - I do not see Jenkins during creation of component - You have wrong URL to catalog URL, you can change it here: `ns/tssc-dh/secrets/tssc-developer-hub-env/yaml` and kill old developer hub pods and wait for new ones
  - Buildah in jenkins job/pipeline does not work - You have not changed agent in Jenkinsfile or the Jenkins agent pod does not run in privileged mode
- - Jenkins job status is not reported back to developer hub - You do not have correct credentials for Jenkins in developer hub, update `ns/rhtap/secrets/developer-hub-rhtap-env/yaml` with correct creds
- - 'Jenkins' doesn't have label 'jenkins-agent' - You need to setup correct Jenkins agent in your Jenkinsfile and check labels, if they are correct. Verify also Jenkins agent settings in Jenkinsfile.
+ - Jenkins job status is not reported back to developer hub - You do not have correct credentials for Jenkins in developer hub, update `ns/tssc-dh/secrets/tssc-developer-hub-env/yaml` with correct creds
  - `error: error processing template "openshift/jenkins-persistent": the namespace of the provided object does not match the namespace sent on the request`
    when running `oc new-app` - your `oc` version may be out of date, try downloading the latest version


### PR DESCRIPTION
Implements RHTAP-6021

Updating readme to remove reference to jenkins agent image built in favor of using runner image