### PR TITLE
Fixing namespace typo

### DIFF
--- a/gitlab-runners/gitlab-ci-sa-scc.yml
+++ b/gitlab-runners/gitlab-ci-sa-scc.yml
@@ -11,7 +11,7 @@ fsGroup:
 kind: SecurityContextConstraints
 metadata:
   name: gitlab-ci-sa-scc
-  namepace: gitlab-runner
+  namespace: gitlab-runner
 priority: 5
 readOnlyRootFilesystem: false
 requiredDropCapabilities:


### PR DESCRIPTION
Noticed this while running some local test